### PR TITLE
Update links

### DIFF
--- a/using-amber/debugging/vs-code-debug.md
+++ b/using-amber/debugging/vs-code-debug.md
@@ -1,13 +1,13 @@
 # VS Code Amber Debug
 
-Debugging an Amber project on VSCode with GDB and [Native Debug](https://github.com/faustinoaq/vscode-crystal-lang#67-debugging).
+Debugging an Amber project on VSCode with GDB and [Native Debug](https://github.com/crystal-lang-tools/vscode-crystal-lang/wiki/Useful-extensions#debugging).
 
 ## Requisites
 
 * Crystal
 * Amber Project - See installation guide [here](/getting-started/Installation/README.md)
-* GNU Debugger \(GDB\) - Mac os install `brew install gdb`
-* VSCode + [Crystal Support](https://marketplace.visualstudio.com/search?term=tag%3Acrystal&target=VSCode&category=All categories&sortBy=Relevance) + [Native Debug](https://github.com/faustinoaq/vscode-crystal-lang#67-debugging)
+* GNU Debugger (GDB) - MacOS install `brew install gdb`
+* VSCode + [Crystal Support](https://marketplace.visualstudio.com/items?itemName=faustinoaq.crystal-lang) + [Native Debug](https://github.com/WebFreak001/code-debug)
 
 > Note: Before continuing setting up the debugger make sure you have the above requisites install. These settings have been verified for a MacOS enviroment.
 
@@ -52,7 +52,13 @@ Debugging an Amber project on VSCode with GDB and [Native Debug](https://github.
 }
 ```
 
-#### 3. Then hit the green play button and whoala![!\[\]\(https://camo.githubusercontent.com/30adba87add4770abf2c3982206748123f8a2c6e/687474703a2f2f692e696d6775722e636f6d2f6d674b41366d782e706e67 &quot;set breakpoint&quot;\)](https://camo.githubusercontent.com/30adba87add4770abf2c3982206748123f8a2c6e/687474703a2f2f692e696d6775722e636f6d2f6d674b41366d782e706e67)[![](https://camo.githubusercontent.com/c5a551366c3eb2464c920bf3f95e8cdfb97ad827/687474703a2f2f692e696d6775722e636f6d2f6b506b546e75442e706e67 "change variable value")](https://camo.githubusercontent.com/c5a551366c3eb2464c920bf3f95e8cdfb97ad827/687474703a2f2f692e696d6775722e636f6d2f6b506b546e75442e706e67)[Native Debug](https://github.com/faustinoaq/vscode-crystal-lang#67-debugging) allows to set breakpoints, watch variables and execute GDB commands inside VSCode.
+#### 3. Then hit the green play button
+
+![green button](https://camo.githubusercontent.com/30adba87add4770abf2c3982206748123f8a2c6e/687474703a2f2f692e696d6775722e636f6d2f6d674b41366d782e706e67)
+
+![change variable value](https://camo.githubusercontent.com/c5a551366c3eb2464c920bf3f95e8cdfb97ad827/687474703a2f2f692e696d6775722e636f6d2f6b506b546e75442e706e67)
+
+[Native Debug](https://github.com/WebFreak001/code-debug) allows to set breakpoints, watch variables and execute GDB commands inside VSCode.
 
 
 


### PR DESCRIPTION
Now vscode-crystal-lang uses a [Wiki](https://github.com/crystal-lang-tools/vscode-crystal-lang/wiki) and belongs to [Crystal tools](https://github.com/crystal-lang-tools) organization